### PR TITLE
Require Python >= 3.7 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,12 @@ setup(
         'requests>=2.0.0',
         'python-dateutil>=2.0.0',
     ],
-    scripts=['scripts/trello-to-deck']
+    scripts=['scripts/trello-to-deck'],
+    python_requires='>=3.7',
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+    ],
 )


### PR DESCRIPTION
And additionally add programming language classifiers for pypi

Fixes #12 