### PR TITLE
Catch key error for background colour

### DIFF
--- a/trello_to_deck/trello.py
+++ b/trello_to_deck/trello.py
@@ -164,7 +164,7 @@ def to_board(trello_json):
             except KeyError:
 ....
         else:
-            background_color = "green"
+            background_color = color_map[None] 
     except KeyError:
         background_color = "green"
 

--- a/trello_to_deck/trello.py
+++ b/trello_to_deck/trello.py
@@ -157,17 +157,13 @@ def to_board(trello_json):
     )
 
     # If background has 24 chars then it is an images
-    try:
-        if len(trello_json.prefs.background) != 24:
-            try:
-                background_color = color_map[trello_json.prefs.background] 
-            except KeyError:
-....
-        else:
+    if len(trello_json.prefs.background) != 24:
+        try:
+            background_color = color_map[trello_json.prefs.background] 
+        except KeyError:
             background_color = color_map[None] 
-    except KeyError:
-        background_color = color_map[None]
-
+    else:
+        background_color = color_map[None] 
 
     return Board(
         trello_json.name, background_color, labels, lists

--- a/trello_to_deck/trello.py
+++ b/trello_to_deck/trello.py
@@ -166,7 +166,7 @@ def to_board(trello_json):
         else:
             background_color = color_map[None] 
     except KeyError:
-        background_color = "green"
+        background_color = color_map[None]
 
 
     return Board(

--- a/trello_to_deck/trello.py
+++ b/trello_to_deck/trello.py
@@ -157,7 +157,13 @@ def to_board(trello_json):
     )
 
     # If background has 24 chars then it is an images
-    background_color = color_map[trello_json.prefs.background] if len(trello_json.prefs.background) != 24 else "green"
+    try:
+        if len(trello_json.prefs.background) != 24:
+            background_color = color_map[trello_json.prefs.background] 
+        else:
+            background_color = "green"
+    except KeyError:
+        background_color = "green"
 
 
     return Board(

--- a/trello_to_deck/trello.py
+++ b/trello_to_deck/trello.py
@@ -159,7 +159,10 @@ def to_board(trello_json):
     # If background has 24 chars then it is an images
     try:
         if len(trello_json.prefs.background) != 24:
-            background_color = color_map[trello_json.prefs.background] 
+            try:
+                background_color = color_map[trello_json.prefs.background] 
+            except KeyError:
+....
         else:
             background_color = "green"
     except KeyError:


### PR DESCRIPTION
I was getting a `KeyError` when setting the background colour (which in my case was `"grey"`). This is now checked for and falls back to the default value of `"green"`. The `color_map` variable could definitely be extended to include `"grey"` but I think that this is more robust.