### PR TITLE
open json_file w/ UTF-8 encoding set

### DIFF
--- a/scripts/trello-to-deck
+++ b/scripts/trello-to-deck
@@ -31,7 +31,7 @@ MAX_TITLE_LENGTH = 100
 def truncate(message, length):
     return message if len(message) <= length else message[:length - 1] + "…"
 
-with open(args.input_json, "r") as json_file:
+with open(args.input_json, "r", encoding='UTF-8') as json_file:
     json_string = json_file.read()
     board: Board = to_board(
         json.loads(json_string, object_hook=lambda d: SimpleNamespace(**d))

--- a/scripts/trello-to-deck
+++ b/scripts/trello-to-deck
@@ -31,7 +31,7 @@ MAX_TITLE_LENGTH = 100
 def truncate(message, length):
     return message if len(message) <= length else message[:length - 1] + "…"
 
-with open(args.input_json, "r", encoding='UTF-8') as json_file:
+with open(args.input_json, "r", encoding='utf8') as json_file:
     json_string = json_file.read()
     board: Board = to_board(
         json.loads(json_string, object_hook=lambda d: SimpleNamespace(**d))
@@ -115,4 +115,3 @@ with open(args.input_json, "r", encoding='UTF-8') as json_file:
     api.attachToCard(nextcloudBoardId, nextcloudStackId, nextcloudCardId, f"{board.title}.json", json_string.encode(), "application/json")
 
     print("Successfully migrated to Deck!")
-


### PR DESCRIPTION
Trello exports its JSON files UTF-8 encoded. Reading them as such allows for German Umlauts to be preserved in Nextcloud's Deck boards.

Remark: Sorry for this drive-by PR. I am currently migrating Trello boards, and encountered encoding problems. I am neither a Python programmer, nor very much a programmer at all. But it seems this does the trick with as few meddling as possible. 
Thanks for considering it, and thanks for providing trello-to-deck. :-)